### PR TITLE
Added Enum and None type annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.idea
+typedecorator.egg-info
+dist
 /build/
 /htmlcov/
 /.coverage

--- a/tests.py
+++ b/tests.py
@@ -2,14 +2,10 @@ import pickle
 from sys import version_info
 from unittest import TestCase, TestLoader, TextTestRunner
 
-from typedecorator import (params, returns, void, setup_typecheck, Union,
-    Nullable)
+from typedecorator import (params, returns, void, Union, Nullable)
 
 
 class TestTypeSignatures(TestCase):
-
-    def setUp(self):
-        setup_typecheck()
 
     def test_params_builtin_type(self):
         @params(a=int)
@@ -176,9 +172,6 @@ class TestTypeSignatures(TestCase):
 
 class TestParams(TestCase):
 
-    def setUp(self):
-        setup_typecheck()
-
     def test_params_args_kwargs(self):
         @params(a=int, b=str)
         def foo(a, b):
@@ -204,9 +197,6 @@ class TestParams(TestCase):
 
 
 class TestReturns(TestCase):
-
-    def setUp(self):
-        setup_typecheck()
 
     def test_returns(self):
         @returns(int)
@@ -247,8 +237,6 @@ class TestSetup(TestCase):
         class MyError(Exception):
             pass
 
-        setup_typecheck(exception=MyError)
-
         @returns(int)
         def foo():
             pass
@@ -256,7 +244,6 @@ class TestSetup(TestCase):
         self.assertRaises(MyError, lambda: foo())
 
     def test_disabled_exception(self):
-        setup_typecheck()
 
         @returns(int)
         def foo():
@@ -264,16 +251,11 @@ class TestSetup(TestCase):
 
         self.assertRaises(TypeError, lambda: foo())
 
-        setup_typecheck(exception=None)
-
         # should not raise anything any more
         foo()
 
 
 class TestMethodAnnotation(TestCase):
-
-    def setUp(self):
-        setup_typecheck()
 
     def test_class_instance_methods(self):
 

--- a/tests3.py
+++ b/tests3.py
@@ -1,12 +1,10 @@
 # Tests using Python3-specific syntax
 from unittest import TestCase, main
 
-from typedecorator import typed, setup_typecheck
+from typedecorator import typed
 
 
 class TestPython3Annotations(TestCase):
-    def setUp(self):
-        setup_typecheck()
 
     def test_typed(self):
 

--- a/typedecorator/__init__.py
+++ b/typedecorator/__init__.py
@@ -214,9 +214,9 @@ def _verify_type_constraint(v, t):
         return all(_verify_type_constraint(vx, tx) for vx in v)
     elif isinstance(t, Union):
         return any(_verify_type_constraint(v, tx) for tx in t)
-    elif isinstance(t, typing._GenericAlias):
+    elif isinstance(t, typing._GenericAlias) and isinstance(v, t):
         return all(_verify_type_constraint(vx, t[0]) for vx in v.__args__)
-    elif isinstance(t, typing._SpecialForm):
+    elif isinstance(t, typing._SpecialForm) and isinstance(v, t):
         if t._name in ('Union', 'Optional'):
             return any(_verify_type_constraint(vx, t[0]) for vx in v.__args__)
         elif t._name == 'Any':

--- a/typedecorator/__init__.py
+++ b/typedecorator/__init__.py
@@ -83,7 +83,7 @@ import inspect
 import logging
 import traceback
 
-__version__ = '0.0.8'
+__version__ = '0.0.6'
 
 __all__ = ['returns', 'void', 'params', 'Union', 'Nullable', 'Enum', 'typed', 'NoneType']
 

--- a/typedecorator/__init__.py
+++ b/typedecorator/__init__.py
@@ -83,9 +83,9 @@ import inspect
 import logging
 import traceback
 
-__version__ = '0.0.6'
+__version__ = '0.0.7'
 
-__all__ = ['returns', 'void', 'params', 'Union', 'Nullable', 'Enum', 'typed']
+__all__ = ['returns', 'void', 'params', 'Union', 'Nullable', 'Enum', 'typed', 'NoneType']
 
 try:
     from mock import Mock
@@ -153,6 +153,8 @@ def _constraint_to_string(t):
         return '{%s}' % _constraint_to_string(list(t)[0])
     elif isinstance(t, Union):
         return 'U(%s)' % (', '.join(_constraint_to_string(x) for x in t))
+    elif isinstance(t, Enum):
+        return 'Enum[%s]' % (', '.join(_constraint_to_string(x) for x in t))
     else:
         raise TypeError('Invalid type signature')
 
@@ -378,3 +380,6 @@ class Enum(object):
 
     def __iter__(self):
         return iter(self.enums)
+
+
+NoneType = type(None)

--- a/typedecorator/__init__.py
+++ b/typedecorator/__init__.py
@@ -83,7 +83,7 @@ import inspect
 import logging
 import traceback
 
-__version__ = '0.0.7'
+__version__ = '0.0.8'
 
 __all__ = ['returns', 'void', 'params', 'Union', 'Nullable', 'Enum', 'typed', 'NoneType']
 
@@ -174,6 +174,8 @@ def _check_constraint_validity(t):
     elif isinstance(t, set) and len(t) == 1:
         return _check_constraint_validity(list(t)[0])
     elif isinstance(t, Union):
+        return all(_check_constraint_validity(x) for x in t)
+    elif isinstance(t, Enum):
         return all(_check_constraint_validity(x) for x in t)
     else:
         raise TypeError('Invalid type signature')

--- a/typedecorator/__init__.py
+++ b/typedecorator/__init__.py
@@ -189,7 +189,9 @@ def class_tree(obj):
 def _verify_type_constraint(v, t):
     if Mock and isinstance(v, Mock):
         return True
-    if t is range_type and hasattr(v, '__iter__') and callable(v.__iter__):
+    if isinstance(t, Enum):
+        return v in t
+    elif t is range_type and hasattr(v, '__iter__') and callable(v.__iter__):
         return True
     elif isinstance(t, type):
         return isinstance(v, t)
@@ -364,3 +366,13 @@ def typed(fn):
 
     fn.__annotations__ = {}
     return fn
+
+
+class Enum(object):
+    __slots__ = ('enums',)
+
+    def __init__(self, *enums):
+        self.enums = enums
+
+    def __iter__(self):
+        return iter(self.enums)

--- a/typedecorator/__init__.py
+++ b/typedecorator/__init__.py
@@ -84,7 +84,7 @@ import logging
 import traceback
 import typing
 
-__version__ = '0.1.1'
+__version__ = '0.1.3'
 
 
 __all__ = ['returns', 'void', 'params', 'Union', 'Nullable', 'Enum', 'typed']
@@ -214,9 +214,9 @@ def _verify_type_constraint(v, t):
         return all(_verify_type_constraint(vx, tx) for vx in v)
     elif isinstance(t, Union):
         return any(_verify_type_constraint(v, tx) for tx in t)
-    elif isinstance(t, typing._GenericAlias) and isinstance(v, t):
+    elif isinstance(t, typing._GenericAlias) and isinstance(v, t.__origin__):
         return all(_verify_type_constraint(vx, t[0]) for vx in v.__args__)
-    elif isinstance(t, typing._SpecialForm) and isinstance(v, t):
+    elif isinstance(t, typing._SpecialForm):
         if t._name in ('Union', 'Optional'):
             return any(_verify_type_constraint(vx, t[0]) for vx in v.__args__)
         elif t._name == 'Any':

--- a/typedecorator/__init__.py
+++ b/typedecorator/__init__.py
@@ -85,7 +85,7 @@ import traceback
 
 __version__ = '0.0.5'
 
-__all__ = ['returns', 'void', 'params', 'Union', 'Nullable', 'typed']
+__all__ = ['returns', 'void', 'params', 'Union', 'Nullable', 'Enum', 'typed']
 
 try:
     from mock import Mock

--- a/typedecorator/__init__.py
+++ b/typedecorator/__init__.py
@@ -83,7 +83,7 @@ import inspect
 import logging
 import traceback
 
-__version__ = '0.0.5'
+__version__ = '0.0.6'
 
 __all__ = ['returns', 'void', 'params', 'Union', 'Nullable', 'Enum', 'typed']
 

--- a/typedecorator/__init__.py
+++ b/typedecorator/__init__.py
@@ -308,8 +308,10 @@ def params(**types):
         else:
             arg_names, va_args, va_kwargs, _ = inspect.getargspec(fn)
 
-        if any(arg not in arg_names for arg in types.keys()) \
-                or any(arg not in types for arg in arg_names):
+        for arg in ['self', 'cls']:
+            if (arg in arg_names) and (arg not in types):
+                types[arg] = object
+        if any(arg not in arg_names for arg in types.keys()) or any(arg not in types for arg in arg_names):
             raise TypeError("Annotation doesn't match function signature")
 
         def wrapper(*args, **kwargs):


### PR DESCRIPTION
- Added `Enum` (enumerator) type annotation and `NoneType`
- Ignore `self `and `cls` arguments - this allows the `typed `decorator to work with class methods
- Removed the `setup_typecheck` function implementation from the whole repo - this implementation works poorly for multi-threaded jobs
